### PR TITLE
Escape double and single quotes in HTML code

### DIFF
--- a/lib/bb-ruby.rb
+++ b/lib/bb-ruby.rb
@@ -6,6 +6,7 @@ module BBRuby
 
   # allowable image formats
   @@imageformats = 'png|bmp|jpg|gif|jpeg'
+  @@quote_matcher = '(&quot;|&apos;|)'
 
   # built-in BBCode tabs that will be processed
   @@tags = {
@@ -53,14 +54,14 @@ module BBRuby
       '[code]some code[/code]',
       :code],
     'Size' => [
-      /\[size=['"]?(.*?)['"]?\](.*?)\[\/size\]/im,
-      '<span style="font-size: \1px;">\2</span>',
+      /\[size=#{@@quote_matcher}(.*?)\1\](.*?)\[\/size\]/im,
+      '<span style="font-size: \2px;">\3</span>',
       'Change text size',
       '[size=20]Here is some larger text[/size]',
       :size],
     'Color' => [
-      /\[color=['"]?(\w+|\#\w{6})['"]?(:.+)?\](.*?)\[\/color\2?\]/im,
-      '<span style="color: \1;">\3</span>',
+      /\[color=#{@@quote_matcher}(\w+|\#\w{6})\1(:.+)?\](.*?)\[\/color\3?\]/im,
+      '<span style="color: \2;">\4</span>',
       'Change text color',
       '[color=red]This is red text[/color]',
       :color],
@@ -155,7 +156,7 @@ module BBRuby
       'Maybe try looking on http://www.google.com',
       :link],  
     'Image (Resized)' => [
-      /\[img(:.+)? size=(['"]?)(\d+)x(\d+)\2\](.*?)\[\/img\1?\]/im,
+      /\[img(:.+)? size=#{@@quote_matcher}(\d+)x(\d+)\2\](.*?)\[\/img\1?\]/im,
       '<img src="\5" style="width: \3px; height: \4px;" />',
       'Display an image with a set width and height', 
       '[img size=96x96]http://www.google.com/intl/en_ALL/images/logo.gif[/img]',

--- a/test/test_bb-ruby.rb
+++ b/test/test_bb-ruby.rb
@@ -44,10 +44,14 @@ class TestBBRuby < Test::Unit::TestCase
   
   def test_size
     assert_equal '<span style="font-size: 32px;">12px Text</span>', '[size=32]12px Text[/size]'.bbcode_to_html
+    assert_equal '<span style="font-size: 32px;">12px Text</span>', '[size="32"]12px Text[/size]'.bbcode_to_html
+    assert_equal '<span style="font-size: 32px;">12px Text</span>', '[size=\'32\']12px Text[/size]'.bbcode_to_html
   end
   
   def test_color
     assert_equal '<span style="color: red;">Red Text</span>', '[color=red]Red Text[/color]'.bbcode_to_html
+    assert_equal '<span style="color: red;">Red Text</span>', '[color="red"]Red Text[/color]'.bbcode_to_html
+    assert_equal '<span style="color: red;">Red Text</span>', '[color=\'red\']Red Text[/color]'.bbcode_to_html
     assert_equal '<span style="color: #ff0023;">Hex Color Text</span>', '[color=#ff0023]Hex Color Text[/color]'.bbcode_to_html
     assert_equal '<span style="color: #B23803;">text</span>', '[color=#B23803:05d7c56429]text[/color:05d7c56429]'.bbcode_to_html
   end
@@ -124,6 +128,8 @@ class TestBBRuby < Test::Unit::TestCase
     assert_equal '<img src="http://zoople/hochzeit.png" style="width: 95px; height: 96px;" />', '[img size=95x96]http://zoople/hochzeit.png[/img]'.bbcode_to_html
     assert_equal '<img src="http://zoople/hochzeit.png" alt="" />', '[img:7a9ca2c5c3]http://zoople/hochzeit.png[/img:7a9ca2c5c3]'.bbcode_to_html
     assert_equal '<img src="http://zoople/hochzeit.png" style="width: 95px; height: 96px;" />', '[img:7a9ca2c5c3 size=95x96]http://zoople/hochzeit.png[/img:7a9ca2c5c3]'.bbcode_to_html
+    assert_equal '<img src="http://zoople/hochzeit.png" style="width: 95px; height: 96px;" />', '[img:7a9ca2c5c3 size="95x96"]http://zoople/hochzeit.png[/img:7a9ca2c5c3]'.bbcode_to_html
+    assert_equal '<img src="http://zoople/hochzeit.png" style="width: 95px; height: 96px;" />', '[img:7a9ca2c5c3 size=\'95x96\']http://zoople/hochzeit.png[/img:7a9ca2c5c3]'.bbcode_to_html
     assert_equal '<img src="http://www.marcodigital.com/sitanddie/sitanddiepequeÃ±o.jpg" alt="" />', '[img:post_uid0]http://www.marcodigital.com/sitanddie/sitanddiepequeÃ±o.jpg[/img:post_uid0]'.bbcode_to_html
   end
   


### PR DESCRIPTION
Fix for issue #2

Changes summary:
- added double and single quotes to list of characters that were escaped before processing BBCode;
- as this broke all code that was using quoted attributes, replaced quote regexps to match escaped quotes;
- coincidentally, fixed the issue where original code would match `[size="10'][/size]` (non-matching quotes);
- added tests to cover the failing case, and the new regexp changes.
