### PR TITLE
Solving the [list][*]list item[/list] converting issue

### DIFF
--- a/lib/bb-ruby.rb
+++ b/lib/bb-ruby.rb
@@ -90,7 +90,7 @@ module BBRuby
       '[*]list item',
       :listitem],
     'Unordered list (alternative)' => [
-      /\[list(:.*)?\]((?:(?!list).)*)\[\/list(:.)?\1?\]/mi,
+      /\[list(:.*)?\]((?:(?!\[list(:.*)?\]).)*)\[\/list(:.)?\1?\]/mi,
       '<ul>\2</ul>',
       'Unordered list item',
       '[list][*]item 1[*] item2[/list]',

--- a/test/test_bb-ruby.rb
+++ b/test/test_bb-ruby.rb
@@ -1,4 +1,5 @@
 #! /usr/bin/env ruby
+#coding: utf-8
 
 require File.dirname(__FILE__) + '/test_helper.rb'
 
@@ -68,6 +69,8 @@ class TestBBRuby < Test::Unit::TestCase
   
   def test_list_unordered
     assert_equal '<ul><li>item 1</li><li>item 2</li></ul>', '[list][li]item 1[/li][li]item 2[/li][/list]'.bbcode_to_html
+    #Added this test which raising an error because of the "list" word in list items. 
+    assert_equal '<ul><li>list item 1</li><li>list item 2</li></ul>', '[list][li]list item 1[/li][li]list item 2[/li][/list]'.bbcode_to_html
     assert_equal '<ul><li>item 1</li><li>item 2</li></ul>', '[list:7a9ca2c5c3][li]item 1[/li][li]item 2[/li][/list:o:7a9ca2c5c3]'.bbcode_to_html
     assert_equal '<ul><li>item 1</li><li>item 2</li></ul><ul><li>item 3</li><li>item 4</li></ul>', 
                  '[list:7a9ca2c5c3][li]item 1[/li][li]item 2[/li][/list:o:7a9ca2c5c3][list:7a9ca2c5c3][li]item 3[/li][li]item 4[/li][/list:o:7a9ca2c5c3]'.bbcode_to_html


### PR DESCRIPTION
Hi, 

So, here is my pull request to solve the issue I found: https://github.com/cpjolicoeur/bb-ruby/issues/4#issuecomment-4110815

I've added a test in the test_bb-ruby.rb file: 
          assert_equal '&lt;ul>&lt;li>list item 1&lt;/li>&lt;li>list item 2&lt;/li>&lt;/ul>', '[list][li]list item 1[/li][li]list item 2[/li][/list]'.bbcode_to_html

Which did not pass before the change I did in the bb-ruby.rb file. Other tests still pass.

No big deal, but it would prevent anyone from using the "list" word in unordered list items. ;)
Hope it helps. ;)
Kulgar. 
