### PR TITLE
NEW: define methods for nil

### DIFF
--- a/lib/bb-ruby.rb
+++ b/lib/bb-ruby.rb
@@ -436,3 +436,23 @@ class String
     self.replace(BBRuby.to_html_with_formatting(self, tags_alternative_definition, escape_html, method, *tags))
   end
 end
+
+class NilClass
+  def bbcode_to_html(tags_alternative_definition = {}, escape_html=true, method=:disable, *tags)
+    ''
+  end
+
+  # Replace the string contents with the HTML-converted markup
+  def bbcode_to_html!(tags_alternative_definition = {}, escape_html=true, method=:disable, *tags)
+    ''
+  end
+
+  def bbcode_to_html_with_formatting(tags_alternative_definition = {}, escape_html=true, method=:disable, *tags)
+    ''
+  end
+
+  # Replace the string contents with the HTML-converted markup using simple_format
+  def bbcode_to_html_with_formatting!(tags_alternative_definition = {}, escape_html=true, method=:disable, *tags)
+    ''
+  end
+end

--- a/test/bb-ruby_test.rb
+++ b/test/bb-ruby_test.rb
@@ -349,4 +349,7 @@ class TestBBRuby < Test::Unit::TestCase
     assert_equal 'One<br />Two<br />Three lines!', 'One[br]Two[br]Three lines!'.bbcode_to_html
   end
 
+  def test_nil
+    assert_equal '', nil.bbcode_to_html
+  end
 end


### PR DESCRIPTION
With this instead of exception, nil gets translated to empty string.