### PR TITLE
Properly close Youtube iframes

### DIFF
--- a/lib/bb-ruby.rb
+++ b/lib/bb-ruby.rb
@@ -183,14 +183,14 @@ module BBRuby
     'YouTube' => [
       /\[youtube\](.*?)\?v=([\w\d\-]+).*?\[\/youtube\]/im,
       # '<object width="400" height="330"><param name="movie" value="http://www.youtube.com/v/\2"></param><param name="wmode" value="transparent"></param><embed src="http://www.youtube.com/v/\2" type="application/x-shockwave-flash" wmode="transparent" width="400" height="330"></embed></object>',
-      '<iframe id="ytplayer" type="text/html" width="640" height="390" src="http://www.youtube.com/embed/\2" frameborder="0"/>',
+      '<iframe id="ytplayer" type="text/html" width="640" height="390" src="http://www.youtube.com/embed/\2" frameborder="0"></iframe>',
       'Display a video from YouTube.com',
       '[youtube]http://youtube.com/watch?v=E4Fbk52Mk1w[/youtube]',
       :video],
     'YouTube (Alternative)' => [
       /\[youtube\](.*?)\/v\/([\w\d\-]+)\[\/youtube\]/im,
       # '<object width="400" height="330"><param name="movie" value="http://www.youtube.com/v/\2"></param><param name="wmode" value="transparent"></param><embed src="http://www.youtube.com/v/\2" type="application/x-shockwave-flash" wmode="transparent" width="400" height="330"></embed></object>',
-      '<iframe id="ytplayer" type="text/html" width="640" height="390" src="http://www.youtube.com/embed/\2" frameborder="0"/>',
+      '<iframe id="ytplayer" type="text/html" width="640" height="390" src="http://www.youtube.com/embed/\2" frameborder="0"></iframe>',
       'Display a video from YouTube.com (alternative format)',
       '[youtube]http://youtube.com/watch/v/E4Fbk52Mk1w[/youtube]',
       :video],

--- a/test/bb-ruby_test.rb
+++ b/test/bb-ruby_test.rb
@@ -143,8 +143,8 @@ class TestBBRuby < Test::Unit::TestCase
   def test_youtube
     # Uncomment below if using 4:3 format youtube video embed
     # assert_equal assert_equal '<iframe id="ytplayer" type="text/html" width="320" height="265" src="http://www.youtube.com/embed/E4Fbk52Mk1w" frameborder="0"/>', '[youtube]http://youtube.com/watch?v=E4Fbk52Mk1w[/youtube]'.bbcode_to_html
-    assert_equal '<iframe id="ytplayer" type="text/html" width="640" height="390" src="http://www.youtube.com/embed/E4Fbk52Mk1w" frameborder="0"/>', '[youtube]http://youtube.com/watch?v=E4Fbk52Mk1w[/youtube]'.bbcode_to_html
-    assert_equal '<iframe id="ytplayer" type="text/html" width="640" height="390" src="http://www.youtube.com/embed/E4Fbk52Mk1w" frameborder="0"/><iframe id="ytplayer" type="text/html" width="640" height="390" src="http://www.youtube.com/embed/abc123" frameborder="0"/>', '[youtube]http://youtube.com/watch?v=E4Fbk52Mk1w[/youtube][youtube]http://youtube.com/watch?v=abc123[/youtube]'.bbcode_to_html
+    assert_equal '<iframe id="ytplayer" type="text/html" width="640" height="390" src="http://www.youtube.com/embed/E4Fbk52Mk1w" frameborder="0"></iframe>', '[youtube]http://youtube.com/watch?v=E4Fbk52Mk1w[/youtube]'.bbcode_to_html
+    assert_equal '<iframe id="ytplayer" type="text/html" width="640" height="390" src="http://www.youtube.com/embed/E4Fbk52Mk1w" frameborder="0"></iframe><iframe id="ytplayer" type="text/html" width="640" height="390" src="http://www.youtube.com/embed/abc123" frameborder="0"></iframe>', '[youtube]http://youtube.com/watch?v=E4Fbk52Mk1w[/youtube][youtube]http://youtube.com/watch?v=abc123[/youtube]'.bbcode_to_html
   end
 
   def test_vimeo


### PR DESCRIPTION
The HTML standard only allows for specific tags that can be empty and self-closing. Tags like `<script>` and `<iframe>` are not in that list.

While the browser renderer will let these slide, Javascript libraries like Bootstrap and jQuery might break things because, per spec, the iframe tag can't be self closing.

I personally ran into this issue while rendering bbcode that had a Youtube embed inside of a Bootstrap tab.

Chrome's source view before (note the lack of color after the `<iframe>` tag:
<img width="1150" alt="chrome-before" src="https://cloud.githubusercontent.com/assets/545604/16137035/a7b01f06-33fd-11e6-8e5e-674d8df58af1.png">

After (with this patch):
<img width="1213" alt="chrome-after" src="https://cloud.githubusercontent.com/assets/545604/16137040/ace5d254-33fd-11e6-884b-7678d48e69f4.png">
