### PR TITLE
Use YouTube iframe URL without a scheme

### DIFF
--- a/lib/bb-ruby.rb
+++ b/lib/bb-ruby.rb
@@ -183,14 +183,14 @@ module BBRuby
     'YouTube' => [
       /\[youtube\](.*?)\?v=([\w\d\-]+).*?\[\/youtube\]/im,
       # '<object width="400" height="330"><param name="movie" value="http://www.youtube.com/v/\2"></param><param name="wmode" value="transparent"></param><embed src="http://www.youtube.com/v/\2" type="application/x-shockwave-flash" wmode="transparent" width="400" height="330"></embed></object>',
-      '<iframe id="ytplayer" type="text/html" width="640" height="390" src="http://www.youtube.com/embed/\2" frameborder="0"></iframe>',
+      '<iframe id="ytplayer" type="text/html" width="640" height="390" src="//youtube.com/embed/\2" frameborder="0"></iframe>',
       'Display a video from YouTube.com',
       '[youtube]http://youtube.com/watch?v=E4Fbk52Mk1w[/youtube]',
       :video],
     'YouTube (Alternative)' => [
       /\[youtube\](.*?)\/v\/([\w\d\-]+)\[\/youtube\]/im,
       # '<object width="400" height="330"><param name="movie" value="http://www.youtube.com/v/\2"></param><param name="wmode" value="transparent"></param><embed src="http://www.youtube.com/v/\2" type="application/x-shockwave-flash" wmode="transparent" width="400" height="330"></embed></object>',
-      '<iframe id="ytplayer" type="text/html" width="640" height="390" src="http://www.youtube.com/embed/\2" frameborder="0"></iframe>',
+      '<iframe id="ytplayer" type="text/html" width="640" height="390" src="//youtube.com/embed/\2" frameborder="0"></iframe>',
       'Display a video from YouTube.com (alternative format)',
       '[youtube]http://youtube.com/watch/v/E4Fbk52Mk1w[/youtube]',
       :video],

--- a/test/bb-ruby_test.rb
+++ b/test/bb-ruby_test.rb
@@ -143,8 +143,8 @@ class TestBBRuby < Test::Unit::TestCase
   def test_youtube
     # Uncomment below if using 4:3 format youtube video embed
     # assert_equal assert_equal '<iframe id="ytplayer" type="text/html" width="320" height="265" src="http://www.youtube.com/embed/E4Fbk52Mk1w" frameborder="0"/>', '[youtube]http://youtube.com/watch?v=E4Fbk52Mk1w[/youtube]'.bbcode_to_html
-    assert_equal '<iframe id="ytplayer" type="text/html" width="640" height="390" src="http://www.youtube.com/embed/E4Fbk52Mk1w" frameborder="0"></iframe>', '[youtube]http://youtube.com/watch?v=E4Fbk52Mk1w[/youtube]'.bbcode_to_html
-    assert_equal '<iframe id="ytplayer" type="text/html" width="640" height="390" src="http://www.youtube.com/embed/E4Fbk52Mk1w" frameborder="0"></iframe><iframe id="ytplayer" type="text/html" width="640" height="390" src="http://www.youtube.com/embed/abc123" frameborder="0"></iframe>', '[youtube]http://youtube.com/watch?v=E4Fbk52Mk1w[/youtube][youtube]http://youtube.com/watch?v=abc123[/youtube]'.bbcode_to_html
+    assert_equal '<iframe id="ytplayer" type="text/html" width="640" height="390" src="//youtube.com/embed/E4Fbk52Mk1w" frameborder="0"></iframe>', '[youtube]http://youtube.com/watch?v=E4Fbk52Mk1w[/youtube]'.bbcode_to_html
+    assert_equal '<iframe id="ytplayer" type="text/html" width="640" height="390" src="//youtube.com/embed/E4Fbk52Mk1w" frameborder="0"></iframe><iframe id="ytplayer" type="text/html" width="640" height="390" src="//youtube.com/embed/abc123" frameborder="0"></iframe>', '[youtube]http://youtube.com/watch?v=E4Fbk52Mk1w[/youtube][youtube]http://youtube.com/watch?v=abc123[/youtube]'.bbcode_to_html
   end
 
   def test_vimeo


### PR DESCRIPTION
Problem: Site using this GEM running under https can't use the YouTube
code due to the resulting iframe being hardcoded to use http.

Specifically, Chrome throws this error in the console:

```
Mixed Content: The page at 'https://mysite.com' was loaded over HTTPS,
but requested an insecure resource 'http://youtube.com/embed/EBh2La1jdag'.
This request has been blocked; the content must be served over HTTPS.
```

This changes the iframe code to use "//youtube.com/..." which is
supported by all major browsers (and is what the Vimeo code is already
doing).